### PR TITLE
Add firmware docs and ROS2 build steps

### DIFF
--- a/Docs/firmware.md
+++ b/Docs/firmware.md
@@ -1,0 +1,20 @@
+# Firmware Build Guide
+
+This document outlines how to compile and flash the STM32 firmware contained in the `firmware/` directory.
+
+## Building with STM32CubeIDE
+
+1. Install **STM32CubeIDE** from the STMicroelectronics website.
+2. Launch the IDE and open the project by selecting the file `firmware/pwm_test.ioc`.
+3. STM32CubeIDE will generate the IDE project automatically.
+4. Connect the controller board via ST‑Link or another programmer.
+5. Click **Build** followed by **Run** to compile and flash the firmware.
+
+## Building with MDK-ARM (Keil)
+
+1. Open `firmware/MDK-ARM/pwm_test.uvprojx` in **Keil uVision**.
+2. Choose the desired build target (e.g. `STM32F103`).
+3. Use the **Build** option to compile the project.
+4. Flash the board using your preferred debug interface.
+
+Both environments generate the same firmware binary. Choose the toolchain that best fits your workflow.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,36 @@ python scripts/rl_games/train.py --task=Template-Mydog-Marl-Direct-v0
 - Use STM32CubeIDE to open `firmware/pwm_test.ioc`
 - Compile and flash to the robot controller board
 - Use ROS 2 packages under `ros2_ws/src/run_saodi/` and `ros2_ws/src/wit_ros2_imu/` for hardware integration
+- See [Docs/firmware.md](Docs/firmware.md) for a full firmware build guide
+
+---
+
+## 🛠️ Building the ROS 2 Workspace
+
+1. Install ROS 2 Humble and source the environment:
+
+   ```bash
+   source /opt/ros/humble/setup.bash
+   ```
+
+2. Install package dependencies with `rosdep`:
+
+   ```bash
+   cd ros2_ws
+   rosdep install --from-paths src -r -y
+   ```
+
+3. Build the workspace using `colcon`:
+
+   ```bash
+   colcon build
+   ```
+
+4. Source the workspace before running the nodes:
+
+   ```bash
+   source install/setup.bash
+   ```
 
 ---
 


### PR DESCRIPTION
## Summary
- add firmware build guide covering STM32CubeIDE and Keil
- document how to build the ROS 2 workspace using `colcon`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841449b74a88320b54396da623eb73e